### PR TITLE
Add docker compose

### DIFF
--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -9,7 +9,12 @@ services:
             - "8080:8080"
         restart: always
         environment:
-            # These addresses should point to your Observation Portal backend deployment
+            # This address should point to your Observation Portal backend deployment.
+            # It is used within the frontend, so it can access localhost outside the docker network.
             -  VUE_APP_OBSERVATION_PORTAL_API_URL=http://127.0.0.1:8000
-            -  INTERNAL_OBSERVATION_PORTAL_API_URL=http://127.0.0.1:8000
+            # This address is used within the docker container, so localhost won't work normally.
+            # Note that when using the default docker network on linux, 172.17.0.1 works
+            # for localhost of the host network, but for mac you will need to use
+            # `host.docker.internal` instead to point to localhost of the host network.
+            -  INTERNAL_OBSERVATION_PORTAL_API_URL=http://172.17.0.1:8000
         entrypoint: /entrypoint.sh

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -1,0 +1,15 @@
+version: '3.7'
+
+# This provides a simple example frontend that can view and schedule Requests using
+# the Observation Portal API backend and components from the ocs-component-lib.
+services:
+    obs_portal_frontend:
+        image: observatorycontrolsystem/ocs-example-frontend:0.1.0
+        ports:
+            - "8080:8080"
+        restart: always
+        environment:
+            # These addresses should point to your Observation Portal backend deployment
+            -  VUE_APP_OBSERVATION_PORTAL_API_URL=http://127.0.0.1:8000
+            -  INTERNAL_OBSERVATION_PORTAL_API_URL=http://127.0.0.1:8000
+        entrypoint: /entrypoint.sh


### PR DESCRIPTION
separate from the observation portal. It uses nginx within its Dockerfile to route to the observation portal backend, so it doesn't need any special config here.